### PR TITLE
Feature/forbidden functions

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -23,6 +23,11 @@
             <property name="spacing" value="0" />
         </properties>
     </rule>
+    <rule ref="Generic.PHP.ForbiddenFunctions">
+        <properties>
+            <property name="forbiddenFunctions" type="array" value="dd=>NULL,die=>NULL,var_dump=>NULL,print_r=>null"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
@@ -58,11 +63,6 @@
     <rule ref="Squiz.Strings.ConcatenationSpacing">
         <properties>
             <property name="spacing" value="1" />
-        </properties>
-    </rule>
-    <rule ref="Generic.PHP.ForbiddenFunctions">
-        <properties>
-            <property name="forbiddenFunctions" type="array" value="dd=>NULL,die=>NULL,var_dump=>NULL, print_r=>null"/>
         </properties>
     </rule>
     <exclude-pattern>_ide_helper.php$</exclude-pattern>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -60,6 +60,11 @@
             <property name="spacing" value="1" />
         </properties>
     </rule>
+    <rule ref="Generic.PHP.ForbiddenFunctions">
+        <properties>
+            <property name="forbiddenFunctions" type="array" value="dd=>NULL,die=>NULL,var_dump=>NULL, print_r=>null"/>
+        </properties>
+    </rule>
     <exclude-pattern>_ide_helper.php$</exclude-pattern>
     <exclude-pattern>_ide_helper_models.php$</exclude-pattern>
     <exclude-pattern>.phpstorm.meta.php</exclude-pattern>


### PR DESCRIPTION
Add forbidden functions to PHPCS so we don't have pull requests that could have stray dd, var_dump, die etc in them, which despite code review could potentially be missed.

This will return a response like so:-

```
---------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
---------------------------------------------------------------------------------------------------
 17 | ERROR | The use of function dd() is forbidden; use NULL() instead
```

use NULL() is not the greatest response however this is how PHPCS handles it https://github.com/squizlabs/PHP_CodeSniffer/issues/263