### PR TITLE
Feature/request validation rule

### DIFF
--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -1,0 +1,20 @@
+name: phpunit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+  steps:
+    - uses: actions/checkout@v2
+    - uses: php-actions/composer@dynamic-docker
+
+    - name: PHPUnit Tests
+      uses: php-actions/phpunit@dynamic-docker
+      with:
+        bootstrap: vendor/autoload.php
+        configuration: phpunit.xml.dist
+        args: --coverage-text

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -10,11 +10,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        
-      - uses: php-actions/composer@dynamic-docker
+
+      - uses: php-actions/composer@v5
 
       - name: PHPUnit Tests
-        uses: php-actions/phpunit@dynamic-docker
+        uses: php-actions/phpunit@v5
         with:
           bootstrap: vendor/autoload.php
           configuration: phpunit.xml.dist

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -5,16 +5,17 @@ on:
   pull_request:
 
 jobs:
-  tests:
+  build-test:
     runs-on: ubuntu-latest
 
-  steps:
-    - uses: actions/checkout@v2
-    - uses: php-actions/composer@dynamic-docker
+    steps:
+      - uses: actions/checkout@v2
+        
+      - uses: php-actions/composer@dynamic-docker
 
-    - name: PHPUnit Tests
-      uses: php-actions/phpunit@dynamic-docker
-      with:
-        bootstrap: vendor/autoload.php
-        configuration: phpunit.xml.dist
-        args: --coverage-text
+      - name: PHPUnit Tests
+        uses: php-actions/phpunit@dynamic-docker
+        with:
+          bootstrap: vendor/autoload.php
+          configuration: phpunit.xml.dist
+          args: --coverage-text

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -1,7 +1,6 @@
 name: phpunit
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -13,8 +13,7 @@ jobs:
       - uses: php-actions/composer@v5
 
       - name: PHPUnit Tests
-        uses: php-actions/phpunit@v5
+        uses: php-actions/phpunit@v9
         with:
-          bootstrap: vendor/autoload.php
           configuration: phpunit.xml.dist
           args: --coverage-text

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 /vendor
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,17 @@
             "role": "Lead Developer"
         }
     ],
+    "autoload": {
+        "psr-4": {
+            "JumpTwentyFour\\PhpCodingStandards\\": "src/"
+        }
+    },
     "require": {
+        "php": "^8.0",
         "squizlabs/php_codesniffer": "^3.5",
-        "slevomat/coding-standard": "^6.4"
+        "slevomat/coding-standard": "^6.4",
+        "nunomaduro/larastan": "^0.6.11",
+        "nikic/php-parser": "^4.0",
+        "laravel/framework": "^6.0|^7.0|^8.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,12 @@
             "JumpTwentyFour\\PhpCodingStandards\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/",
+            "JumpTwentyFour\\PhpCodingStandards\\": "src/"
+        }
+    },
     "require": {
         "php": "^8.0",
         "squizlabs/php_codesniffer": "^3.5",
@@ -22,5 +28,8 @@
         "nunomaduro/larastan": "^0.6.11",
         "nikic/php-parser": "^4.0",
         "laravel/framework": "^6.0|^7.0|^8.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.3 || ^8.2 || ^9.3"
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -63,6 +63,7 @@
     <rule ref="Squiz.Strings.ConcatenationSpacing">
         <properties>
             <property name="spacing" value="1" />
+            <property name="ignoreNewlines" value="true"/>
         </properties>
     </rule>
     <exclude-pattern>_ide_helper.php$</exclude-pattern>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,16 @@
+includes:
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - vendor/nunomaduro/larastan/extension.neon
+
+parameters:
+    level: 8
+    paths:
+        - app
+    excludePaths:
+        - '.phpstorm.meta.php'
+        - '_ide_helper.php'
+        - 'server.php'
+    checkMissingIterableValueType: false
+
+rules:
+    - JumpTwentyFour\PhpCodingStandards\Laravel\PHPStan\RequestValidationRule

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         verbose="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Laravel/PHPStan/RequestValidationRule.php
+++ b/src/Laravel/PHPStan/RequestValidationRule.php
@@ -4,10 +4,12 @@ namespace JumpTwentyFour\PhpCodingStandards\Laravel\PHPStan;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use PhpParser\Node\Expr\MethodCall;
-use PHPStan\Rules\Rule;
 use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\ObjectType;
 
 class RequestValidationRule implements Rule
 {
@@ -26,18 +28,34 @@ class RequestValidationRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if (! $node->name instanceof Node\Identifier || $node->name->toString() !== 'validate') {
+        if (!$node->name instanceof Node\Identifier || $node->name->toString() !== 'validate') {
             return [];
         }
-
-        if (! $this->isCalledOn($node->var, $scope, Request::class) &&
-            ! $this->isCalledOn($node->var, $scope, Controller::class)) {
+        if (
+            !$this->isCalledOn($node->var, $scope, Request::class)
+            && !$this->isCalledOn($node->var, $scope, Controller::class)
+        ) {
             // Method was not called on a Request or Controller, so no errors.
             return [];
         }
 
         return ["All request validation should be done in the form of a form request "
             . "https://laravel.com/docs/8.x/validation#form-request-validation and not performed inline in a "
-            . " controller to ensure a separation of concerns."];
+            . "controller to ensure a separation of concerns."];
+    }
+
+    /**
+     * Determine whether the Expr was called on a class instance.
+     *
+     * @param \PhpParser\Node\Expr $expr
+     * @param \PHPStan\Analyser\Scope $scope
+     * @param string $className
+     * @return bool
+     */
+    protected function isCalledOn(Expr $expr, Scope $scope, string $className)
+    {
+        $calledOnType = $scope->getType($expr);
+
+        return (new ObjectType($className))->isSuperTypeOf($calledOnType)->yes();
     }
 }

--- a/src/Laravel/PHPStan/RequestValidationRule.php
+++ b/src/Laravel/PHPStan/RequestValidationRule.php
@@ -39,20 +39,15 @@ class RequestValidationRule implements Rule
             return [];
         }
 
-        return ["All request validation should be done in the form of a form request "
-            . "https://laravel.com/docs/8.x/validation#form-request-validation and not performed inline in a "
-            . "controller to ensure a separation of concerns."];
+        return ['All request validation should be done in the form of a form request ' .
+            'https://laravel.com/docs/8.x/validation#form-request-validation and not performed inline in a ' .
+            'controller to ensure a separation of concerns.'];
     }
 
     /**
      * Determine whether the Expr was called on a class instance.
-     *
-     * @param \PhpParser\Node\Expr $expr
-     * @param \PHPStan\Analyser\Scope $scope
-     * @param string $className
-     * @return bool
-     */
-    protected function isCalledOn(Expr $expr, Scope $scope, string $className)
+    */
+    protected function isCalledOn(Expr $expr, Scope $scope, string $className): bool
     {
         $calledOnType = $scope->getType($expr);
 

--- a/src/Laravel/PHPStan/RequestValidationRule.php
+++ b/src/Laravel/PHPStan/RequestValidationRule.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace JumpTwentyFour\PhpCodingStandards\Laravel\PHPStan;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Rules\Rule;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+
+class RequestValidationRule implements Rule
+{
+    /**
+     * @return string
+     */
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param Node $node
+     * @param Scope $scope
+     * @return string[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $node->name instanceof Node\Identifier || $node->name->toString() !== 'validate') {
+            return [];
+        }
+
+        if (! $this->isCalledOn($node->var, $scope, Request::class) &&
+            ! $this->isCalledOn($node->var, $scope, Controller::class)) {
+            // Method was not called on a Request or Controller, so no errors.
+            return [];
+        }
+
+        return ["All request validation should be done in the form of a form request "
+            . "https://laravel.com/docs/8.x/validation#form-request-validation and not performed inline in a "
+            . " controller to ensure a separation of concerns."];
+    }
+}

--- a/tests/Laravel/PHPStan/Data/test-request-validate.php
+++ b/tests/Laravel/PHPStan/Data/test-request-validate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Laravel\PHPStan\Data;
+
+use Illuminate\Http\Request;
+
+class TestControllerUsingRequestValidation
+{
+    public function __invoke(Request $request)
+    {
+        $request->validate(['test-rule' => 'required']);
+    }
+}

--- a/tests/Laravel/PHPStan/RequestValidationRuleTest.php
+++ b/tests/Laravel/PHPStan/RequestValidationRuleTest.php
@@ -22,7 +22,7 @@ class RequestValidationRuleTest extends RuleTestCase
                     'All request validation should be done in the form of a form request ' .
                     'https://laravel.com/docs/8.x/validation#form-request-validation and not performed inline in a ' .
                     'controller to ensure a separation of concerns.',
-                    15,
+                    11,
                 ],
             ]
         );

--- a/tests/Laravel/PHPStan/RequestValidationRuleTest.php
+++ b/tests/Laravel/PHPStan/RequestValidationRuleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Laravel\PHPStan;
+
+use JumpTwentyFour\PhpCodingStandards\Laravel\PHPStan\RequestValidationRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+class RequestValidationRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new RequestValidationRule();
+    }
+
+    public function testRequestValidationFails(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/Data/test-request-validate.php'],
+            [
+                'Test Request::validate() fails' => [
+                    'All request validation should be done in the form of a form request ' .
+                    'https://laravel.com/docs/8.x/validation#form-request-validation and not performed inline in a ' .
+                    'controller to ensure a separation of concerns.',
+                    15,
+                ],
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Add a request validation rule so that validation is enforced via form request objects for consistency. Unfortunately I could not test validate() via the ValidatesRequests trait in PHPUnit as it was causing a memory leak and crashing PHPUnit and PHPStan. Which is odd given it works in a normal stan run and picks up the errors.

I've also made a tweak to the concat spacing rule as it was flagging up issues on new lines.

Note: I want to set up some sort of CI against this so will probably wait for that until merge.