### PR TITLE
Make CamelCapsFunctionName not strict

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -62,7 +62,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services = $containerConfigurator->services();
 
-    $services->set(CamelCapsFunctionNameSniff::class);
+    $services->set(CamelCapsFunctionNameSniff::class)->property('strict', false);
 
     $services->set(SpaceAfterCastSniff::class)->property('spacing', 0);
     $services->set(SpaceAfterNotSniff::class)->property('spacing', 0);


### PR DESCRIPTION
When this is strict you cannot have two capital letters together so 

`public function notAMember(): self`

isn't allowed.

Setting the strictness to false will allow this.