### PR TITLE
Add more sniffs 😈

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -16,11 +16,13 @@ use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
 use SlevomatCodingStandard\Sniffs\Arrays\TrailingArrayCommaSniff;
 use SlevomatCodingStandard\Sniffs\Classes\ClassConstantVisibilitySniff;
+use SlevomatCodingStandard\Sniffs\Classes\TraitUseDeclarationSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\EmptyCommentSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\UselessFunctionDocCommentSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\EarlyExitSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\NewWithParenthesesSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\RequireNullCoalesceOperatorSniff;
+use SlevomatCodingStandard\Sniffs\ControlStructures\UselessTernaryOperatorSniff;
 use SlevomatCodingStandard\Sniffs\Exceptions\DeadCatchSniff;
 use SlevomatCodingStandard\Sniffs\Functions\UnusedInheritedVariablePassedToClosureSniff;
 use SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff;
@@ -29,13 +31,18 @@ use SlevomatCodingStandard\Sniffs\Namespaces\AlphabeticallySortedUsesSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\MultipleUsesPerLineSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\UnusedUsesSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\UseFromSameNamespaceSniff;
+use SlevomatCodingStandard\Sniffs\Operators\DisallowEqualOperatorsSniff;
 use SlevomatCodingStandard\Sniffs\PHP\ShortListSniff;
 use SlevomatCodingStandard\Sniffs\PHP\TypeCastSniff;
 use SlevomatCodingStandard\Sniffs\PHP\UselessParenthesesSniff;
 use SlevomatCodingStandard\Sniffs\PHP\UselessSemicolonSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\DisallowMixedTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\LongTypeHintsSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\NullableTypeForNullDefaultValueSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSpacingSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSpacingSniff;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayOpenerAndCloserNewlineFixer;
@@ -56,6 +63,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::SKIP, [
         CamelCapsFunctionNameSniff::class => [
             '/tests/**',
+        ],
+        'SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff.MissingTraversableTypeHintSpecification' => [
+            '*'
+        ],
+        'SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff.MissingTraversableTypeHintSpecification' => [
+            '*'
         ],
     ]);
 
@@ -109,4 +122,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(SelfAccessorFixer::class);
     $services->set(ArrayIndentationFixer::class);
     $services->set(ArrayOpenerAndCloserNewlineFixer::class);
+    $services->set(DisallowEqualOperatorsSniff::class);
+    $services->set(TraitUseDeclarationSniff::class);
+    $services->set(DeclareStrictTypesSniff::class);
+    $services->set(ReturnTypeHintSniff::class);
+    $services->set(UselessTernaryOperatorSniff::class);
+    $services->set(DisallowMixedTypeHintSniff::class);
+    $services->set(ParameterTypeHintSniff::class);
 };

--- a/ecs.php
+++ b/ecs.php
@@ -14,6 +14,7 @@ use PhpCsFixer\Fixer\ArrayNotation\TrailingCommaInMultilineArrayFixer;
 use PhpCsFixer\Fixer\ClassNotation\NoBlankLinesAfterClassOpeningFixer;
 use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
+use SlevomatCodingStandard\Sniffs\Arrays\SingleLineArrayWhitespaceSniff;
 use SlevomatCodingStandard\Sniffs\Arrays\TrailingArrayCommaSniff;
 use SlevomatCodingStandard\Sniffs\Classes\ClassConstantVisibilitySniff;
 use SlevomatCodingStandard\Sniffs\Classes\TraitUseDeclarationSniff;
@@ -129,4 +130,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(UselessTernaryOperatorSniff::class);
     $services->set(DisallowMixedTypeHintSniff::class);
     $services->set(ParameterTypeHintSniff::class);
+    $services->set(SingleLineArrayWhitespaceSniff::class);
 };


### PR DESCRIPTION
Added more sniffs to enforce stricter coding standards and catch issues commonly requested or missed in code reviews. 

`$services->set(DisallowEqualOperatorsSniff::class);` 
**What**:  Disallows the use of `==` and `!=` and enforces the use of `===` and `!==`
**Why**: Enforcing type-strict comparisons will make our code stricter and safer from unexpected conversions

`$services->set(TraitUseDeclarationSniff::class);` 
**What**: Enforce multiple use statements instead of comma separating traits
**Why**: We do that anyway and it will do it for us 😅 Provides better organisation and makes it more readable

`$services->set(DeclareStrictTypesSniff::class);`
**What**: Will add `declare(strict_types=1);` at the top of each file
**Why**: Stricter typing 👍🏻 and makes the app more robust

`$services->set(ReturnTypeHintSniff::class);` 
**What**: Enforces return type hints
**Why**: Developer experience, neater code and readability

`$services->set(UselessTernaryOperatorSniff::class);`
**What**:  Removes useless statements where both sides return true or false
**Why**: Removes stale code that is not needed

`$services->set(DisallowMixedTypeHintSniff::class);`
**What**: No mixed type hints allowed 🚫
**Why**: 👆🏻

`$services->set(ParameterTypeHintSniff::class);`  
**What**: Enforces parameter type hints
**Why**: Makes it more readable, consistent and improves developer experience

`$services->set(SingleLineArrayWhitespaceSniff::class)`
**What**: Ensures that there is no whitespace between array brackets and first/last key 
**Why**: Consistency with our current standards

