### PR TITLE
UPDATE: slevomat coding standards & Fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,12 @@
             "email": "steve@jump24.co.uk",
             "homepage": "https://jump24.co.uk",
             "role": "Engineering Manager"
+        },
+        {
+            "name": "Mante Balzaraviciute",
+            "email": "mante@jump24.co.uk",
+            "homepage": "https://jump24.co.uk",
+            "role": "Backend Developer"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,6 @@
             "role": "Senior Developer"
         },
         {
-            "name": "Steve McDougall",
-            "email": "steve@jump24.co.uk",
-            "homepage": "https://jump24.co.uk",
-            "role": "Engineering Manager"
-        },
-        {
             "name": "Mante Balzaraviciute",
             "email": "mante@jump24.co.uk",
             "homepage": "https://jump24.co.uk",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "slevomat/coding-standard": "^7.0",
+        "slevomat/coding-standard": "^8.0",
         "symplify/easy-coding-standard": "^10.0.6",
         "nikic/php-parser": "^4.0"
     },

--- a/ecs.php
+++ b/ecs.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnusedFunctionParameterSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterCastSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterNotSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff;
@@ -16,7 +17,9 @@ use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
 use SlevomatCodingStandard\Sniffs\Arrays\SingleLineArrayWhitespaceSniff;
 use SlevomatCodingStandard\Sniffs\Arrays\TrailingArrayCommaSniff;
+use SlevomatCodingStandard\Sniffs\Classes\BackedEnumTypeSpacingSniff;
 use SlevomatCodingStandard\Sniffs\Classes\ClassConstantVisibilitySniff;
+use SlevomatCodingStandard\Sniffs\Classes\MethodSpacingSniff;
 use SlevomatCodingStandard\Sniffs\Classes\TraitUseDeclarationSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\EmptyCommentSniff;
 use SlevomatCodingStandard\Sniffs\Commenting\UselessFunctionDocCommentSniff;
@@ -30,6 +33,7 @@ use SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff;
 use SlevomatCodingStandard\Sniffs\Functions\UselessParameterDefaultValueSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\AlphabeticallySortedUsesSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\MultipleUsesPerLineSniff;
+use SlevomatCodingStandard\Sniffs\Namespaces\NamespaceSpacingSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\UnusedUsesSniff;
 use SlevomatCodingStandard\Sniffs\Namespaces\UseFromSameNamespaceSniff;
 use SlevomatCodingStandard\Sniffs\Operators\DisallowEqualOperatorsSniff;
@@ -65,28 +69,34 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         CamelCapsFunctionNameSniff::class => [
             '/tests/**',
         ],
-        'SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff.MissingTraversableTypeHintSpecification' => [
-            '*'
-        ],
-        'SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff.MissingTraversableTypeHintSpecification' => [
-            '*'
-        ],
+        'SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff.MissingTraversableTypeHintSpecification',
+        'SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff.MissingTraversableTypeHintSpecification',
+        'SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff.MissingNativeTypeHint',
+        'SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff.MissingNativeTypeHint',
+        'SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff.UselessAnnotation',
+        'SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff.UselessAnnotation',
     ]);
 
     $services = $containerConfigurator->services();
 
     $services->set(CamelCapsFunctionNameSniff::class);
 
-    $services->set(SpaceAfterCastSniff::class)->property('spacing', 0);
-    $services->set(SpaceAfterNotSniff::class)->property('spacing', 0);
-    $services->set(ForbiddenFunctionsSniff::class)->property('forbiddenFunctions', [
-        'dd' => null,
-        'die' => null,
-        'var_dump' => null,
-        'print_r' => null,
-        'ray' => null,
-    ]);
-    $services->set(BooleanOperatorPlacementSniff::class)->property('allowOnly', 'first');
+    $services->set(SpaceAfterCastSniff::class)
+        ->property('spacing', 0);
+
+    $services->set(SpaceAfterNotSniff::class)
+        ->property('spacing', 0);
+
+    $services->set(ForbiddenFunctionsSniff::class)
+        ->property('forbiddenFunctions', [
+            'dd' => null,
+            'die' => null,
+            'var_dump' => null,
+            'print_r' => null,
+            'ray' => null,
+        ]);
+    $services->set(BooleanOperatorPlacementSniff::class)
+        ->property('allowOnly', 'first');
 
     $services->set(TrailingArrayCommaSniff::class);
     $services->set(ClassConstantVisibilitySniff::class);
@@ -111,8 +121,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(NullableTypeForNullDefaultValueSniff::class);
     $services->set(ParameterTypeHintSpacingSniff::class);
     $services->set(ReturnTypeHintSpacingSniff::class);
+    $services->set(ControlSignatureSniff::class)
+        ->property('requiredSpacesBeforeColon', 0);
 
-    $services->set(ControlSignatureSniff::class)->property('requiredSpacesBeforeColon', 0);
     $services->set(CommentedOutCodeSniff::class, '25');
     $services->set(ConcatenationSpacingSniff::class)
         ->property('spacing', 1)
@@ -125,10 +136,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ArrayOpenerAndCloserNewlineFixer::class);
     $services->set(DisallowEqualOperatorsSniff::class);
     $services->set(TraitUseDeclarationSniff::class);
-    $services->set(DeclareStrictTypesSniff::class);
+    $services->set(DeclareStrictTypesSniff::class)
+        ->property('spacesCountAroundEqualsSign', 0);
+
     $services->set(ReturnTypeHintSniff::class);
     $services->set(UselessTernaryOperatorSniff::class);
-    $services->set(DisallowMixedTypeHintSniff::class);
-    $services->set(ParameterTypeHintSniff::class);
+    $services->set(ParameterTypeHintSniff::class)
+        ->property('enableMixedTypeHint', false);
+
     $services->set(SingleLineArrayWhitespaceSniff::class);
+    $services->set(NamespaceSpacingSniff::class);
+    $services->set(MethodSpacingSniff::class);
+    $services->set(BackedEnumTypeSpacingSniff::class);
+    $services->set(UnusedFunctionParameterSniff::class);
 };


### PR DESCRIPTION
Updated Slevomat as they added a new Sniff `$services->set(BackedEnumTypeSpacingSniff::class);` requested by @AlexJump24  
**What**:  Checks the amount of spaces that is before and after the colon on the enum definition
**Why**:  So we can keep our code consistent  🙏🏼 `MantesEnum: string`

`$services->set(NamespaceSpacingSniff::class);`
**What**:  A little sniff to check that there is one line above the namespace and one below👃🏻
**Why**: To keep it nice and consistent 

`$services->set(MethodSpacingSniff::class);`
**What**:  Enforces one new line between methods ✅
**Why**: Another sniff to check the spacing between our methods 

`$services->set(UnusedFunctionParameterSniff::class);`
**What**:  Checks for unused parameters in functions
**Why**: Helps us keep our code clean and only have parameters we use 🤓

Removed: `$services->set(DisallowMixedTypeHintSniff::class);` ❌
**Why**: Sometimes we need to have mixed in the doc blocks, but i disallowed mixed in return types and param types, will make a new PR with a custom sniff that will allow us to have mixed in the doc blocks but not the code itself.

```
$services->set(DeclareStrictTypesSniff::class)
        ->property('spacesCountAroundEqualsSign', 0);
```
**What**:  Updated the sniff to have 0 spaces around the equals as the fixer adds them without spaces 👍🏻
**Why**: To keep it nice and consistent 😎

```
'SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff.MissingNativeTypeHint',
'SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff.MissingNativeTypeHint',
'SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff.UselessAnnotation',
'SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff.UselessAnnotation',
```
**Why**:  Added some excludes for type hints. The above ignore the missing native type hint when the doc block is present. This is needed as we override some Laravel methods that do not like type hints. 🥲 This way the fixer doesn't remove the doc blocks and insert them into param type hints and break the app due to incompatibilities 🔥