### PR TITLE
ADD: camelCase variable name sniff

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -9,6 +9,7 @@ use PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunction
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
 use PHP_CodeSniffer\Standards\PSR12\Sniffs\ControlStructures\BooleanOperatorPlacementSniff;
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ControlSignatureSniff;
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidVariableNameSniff;
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\CommentedOutCodeSniff;
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\Strings\ConcatenationSpacingSniff;
 use PhpCsFixer\Fixer\ArrayNotation\TrailingCommaInMultilineArrayFixer;
@@ -69,6 +70,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         CamelCapsFunctionNameSniff::class => [
             '/tests/**',
         ],
+        'PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidVariableNameSniff.PrivateNoUnderscore',
+        'PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidVariableNameSniff.MemberNotCamelCaps',
         'SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff.MissingTraversableTypeHintSpecification',
         'SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff.MissingTraversableTypeHintSpecification',
         'SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff.MissingNativeTypeHint',
@@ -149,4 +152,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(MethodSpacingSniff::class);
     $services->set(BackedEnumTypeSpacingSniff::class);
     $services->set(UnusedFunctionParameterSniff::class);
+    $services->set(ValidVariableNameSniff::class);
 };


### PR DESCRIPTION
Issue: https://github.com/JumpTwentyFour/php-coding-standards/issues/24

#### Added the camelCase variable name sniff. 
I could not find a fixer for this so the fixes will need to be done manually. 🥹


Will show this: 
<img width="1052" alt="Screenshot 2023-03-23 at 09 47 55" src="https://user-images.githubusercontent.com/104358053/227187111-00be5c2a-d8ee-4f35-8aee-d2cc89aadcc6.png">
