### PR TITLE
ADD: New sniff for final controller

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,11 @@
         "symplify/easy-coding-standard": "^10.0.6",
         "nikic/php-parser": "^4.0"
     },
+    "autoload": {
+        "psr-4": {
+            "PhpCodingStandards\\": "src"
+        }
+    },
     "prefer-stable": true,
     "minimum-stability": "dev",
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "autoload": {
         "psr-4": {
-            "PhpCodingStandards\\": "src"
+            "JumpTwentyFour\\PhpCodingStandards\\": "src"
         }
     },
     "prefer-stable": true,

--- a/ecs.php
+++ b/ecs.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JumpTwentyFour\PhpCodingStandards\Sniffs\FinalControllerSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\UnusedFunctionParameterSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterCastSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceAfterNotSniff;
@@ -11,7 +12,6 @@ use PHP_CodeSniffer\Standards\PSR12\Sniffs\ControlStructures\BooleanOperatorPlac
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ControlSignatureSniff;
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\CommentedOutCodeSniff;
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\Strings\ConcatenationSpacingSniff;
-use PhpCodingStandards\Sniffs\FinalControllerSniff;
 use PhpCsFixer\Fixer\ArrayNotation\TrailingCommaInMultilineArrayFixer;
 use PhpCsFixer\Fixer\ClassNotation\NoBlankLinesAfterClassOpeningFixer;
 use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;

--- a/ecs.php
+++ b/ecs.php
@@ -11,6 +11,7 @@ use PHP_CodeSniffer\Standards\PSR12\Sniffs\ControlStructures\BooleanOperatorPlac
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ControlSignatureSniff;
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\CommentedOutCodeSniff;
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\Strings\ConcatenationSpacingSniff;
+use PhpCodingStandards\Sniffs\FinalControllerSniff;
 use PhpCsFixer\Fixer\ArrayNotation\TrailingCommaInMultilineArrayFixer;
 use PhpCsFixer\Fixer\ClassNotation\NoBlankLinesAfterClassOpeningFixer;
 use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;
@@ -149,4 +150,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(MethodSpacingSniff::class);
     $services->set(BackedEnumTypeSpacingSniff::class);
     $services->set(UnusedFunctionParameterSniff::class);
+    $services->set(FinalControllerSniff::class);
 };

--- a/src/Sniffs/FinalControllerSniff.php
+++ b/src/Sniffs/FinalControllerSniff.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+class FinalControllerSniff implements Sniff
+{
+    public const CONTROLLER_NOT_FINAL = 'ControllerNotFinal';
+
+    public function register(): array
+    {
+        return [
+            T_CLASS,
+        ];
+    }
+
+    public function process(File $phpcsFile, $classPointer): void
+    {
+        $previousPointer = TokenHelper::findPreviousEffective($phpcsFile, $classPointer - 1);
+
+        $tokens = $phpcsFile->getTokens();
+
+        $className = $phpcsFile->getDeclarationName($classPointer);
+
+        if (str_contains($className, 'Test')) {
+            return;
+        }
+
+        if (str_contains($className, 'Controller') === false) {
+            return;
+        }
+
+        if ($tokens[$previousPointer]['code'] === T_FINAL) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableError(
+            'All controllers should be declared using "final" keyword.',
+            $classPointer - 1,
+            self::CONTROLLER_NOT_FINAL
+        );
+
+        if ($fix === false) {
+            return;
+        }
+
+        $phpcsFile->fixer->beginChangeset();
+        $phpcsFile->fixer->addContent($classPointer - 1, 'final ');
+        $phpcsFile->fixer->endChangeset();
+    }
+}

--- a/src/Sniffs/FinalControllerSniff.php
+++ b/src/Sniffs/FinalControllerSniff.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace PhpCodingStandards\Sniffs;
+
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\TokenHelper;

--- a/src/Sniffs/FinalControllerSniff.php
+++ b/src/Sniffs/FinalControllerSniff.php
@@ -27,6 +27,10 @@ class FinalControllerSniff implements Sniff
 
         $className = $phpcsFile->getDeclarationName($classPointer);
 
+        if ($className === 'Controller') {
+            return;
+        }
+
         if (str_contains($className, 'Test')) {
             return;
         }

--- a/src/Sniffs/FinalControllerSniff.php
+++ b/src/Sniffs/FinalControllerSniff.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhpCodingStandards\Sniffs;
+namespace JumpTwentyFour\PhpCodingStandards\Sniffs;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;


### PR DESCRIPTION
Issue: https://github.com/JumpTwentyFour/php-coding-standards/issues/25

### Added a new sniff for checking that controllers are final
- This also works with fixer as well. ✌🏻


Example:
<img width="841" alt="Screenshot 2023-03-23 at 12 13 21" src="https://user-images.githubusercontent.com/104358053/227223428-642e101e-3253-4f6b-a397-dde9f4234c9f.png">

